### PR TITLE
Json output olemeta

### DIFF
--- a/oletools/olemeta.py
+++ b/oletools/olemeta.py
@@ -130,35 +130,16 @@ def process_output(meta, output):
                 t.write_row([prop, value], colors=[None, 'yellow'])
         t.close()
     else:
-
-        # output_dict = defaultdict.fromkeys(["SUMMARY_ATTRIBS", "DOCSUM_ATTRIBS"], None)
-        output_dict = mydict = {"SUMMARY_ATTRIBS": {}, "DOCSUM_ATTRIBS": {}}
+        output_dict = {"SUMMARY_ATTRIBS": {}, "DOCSUM_ATTRIBS": {}}
         for prop in meta.SUMMARY_ATTRIBS:
             value = getattr(meta, prop)
             if value is not None:
-                # TODO: pretty printing for strings, dates, numbers
-                # TODO: better unicode handling
-                # print('- %s: %s' % (prop, value))
-                # if isinstance(value, unicode):
-                #     # encode to UTF8, avoiding errors
-                #     value = value.encode('utf-8', errors='replace')
-                # else:
-                #     value = str(value)
-                output_dict['SUMMARY_ATTRIBS'].update(prop = value)
+                output_dict['SUMMARY_ATTRIBS'][prop] = value
         for prop in meta.DOCSUM_ATTRIBS:
             value = getattr(meta, prop)
             if value is not None:
-                # TODO: pretty printing for strings, dates, numbers
-                # TODO: better unicode handling
-                # print('- %s: %s' % (prop, value))
-                # if isinstance(value, unicode):
-                #     # encode to UTF8, avoiding errors
-                #     value = value.encode('utf-8', errors='replace')
-                # else:
-                #     value = str(value)
                 output_dict['DOCSUM_ATTRIBS'][prop] = value
-
-        print(output_dict)
+        return output_dict
 
 
 
@@ -182,7 +163,8 @@ def main():
     parser.add_option("-f", "--zipfname", dest='zip_fname', type='str', default='*',
                       help='if the file is a zip archive, file(s) to be opened within the zip. Wildcards * and ? are supported. (default:*)')
     parser.add_option("-o", "--output", dest='output', type='str', default="table",
-                      help="output in 'table' or 'json' format")
+                      help="output in 'table' or 'json' format. Table output is the default and appropriate for interactive use, while json \
+                      output is suited to automation")
 
     # TODO: add logfile option
     # parser.add_option('-l', '--loglevel', dest="loglevel", action="store", default=DEFAULT_LOG_LEVEL,

--- a/oletools/olemeta.py
+++ b/oletools/olemeta.py
@@ -62,7 +62,7 @@ __version__ = '0.54'
 
 #=== IMPORTS =================================================================
 
-import sys, os, optparse
+import sys, os, optparse, collections, json
 
 # IMPORTANT: it should be possible to run oletools directly as scripts
 # in any directory without installing them with pip or setup.py.
@@ -88,43 +88,81 @@ def process_ole(ole):
     # parse and display metadata:
     meta = ole.get_metadata()
 
+    return meta
+
+def process_output(meta, output):
+
     # console output with UTF8 encoding:
     ensure_stdout_handles_unicode()
 
     # TODO: move similar code to a function
+    if output == 'table':
+        print('Properties from the SummaryInformation stream:')
+        t = tablestream.TableStream([21, 30], header_row=['Property', 'Value'])
+        for prop in meta.SUMMARY_ATTRIBS:
+            value = getattr(meta, prop)
+            if value is not None:
+                # TODO: pretty printing for strings, dates, numbers
+                # TODO: better unicode handling
+                # print('- %s: %s' % (prop, value))
+                # if isinstance(value, unicode):
+                #     # encode to UTF8, avoiding errors
+                #     value = value.encode('utf-8', errors='replace')
+                # else:
+                #     value = str(value)
+                t.write_row([prop, value], colors=[None, 'yellow'])
+        t.close()
+        print('')
 
-    print('Properties from the SummaryInformation stream:')
-    t = tablestream.TableStream([21, 30], header_row=['Property', 'Value'])
-    for prop in meta.SUMMARY_ATTRIBS:
-        value = getattr(meta, prop)
-        if value is not None:
-            # TODO: pretty printing for strings, dates, numbers
-            # TODO: better unicode handling
-            # print('- %s: %s' % (prop, value))
-            # if isinstance(value, unicode):
-            #     # encode to UTF8, avoiding errors
-            #     value = value.encode('utf-8', errors='replace')
-            # else:
-            #     value = str(value)
-            t.write_row([prop, value], colors=[None, 'yellow'])
-    t.close()
-    print('')
+        print('Properties from the DocumentSummaryInformation stream:')
+        t = tablestream.TableStream([21, 30], header_row=['Property', 'Value'])
+        for prop in meta.DOCSUM_ATTRIBS:
+            value = getattr(meta, prop)
+            if value is not None:
+                # TODO: pretty printing for strings, dates, numbers
+                # TODO: better unicode handling
+                # print('- %s: %s' % (prop, value))
+                # if isinstance(value, unicode):
+                #     # encode to UTF8, avoiding errors
+                #     value = value.encode('utf-8', errors='replace')
+                # else:
+                #     value = str(value)
+                t.write_row([prop, value], colors=[None, 'yellow'])
+        t.close()
+    else:
 
-    print('Properties from the DocumentSummaryInformation stream:')
-    t = tablestream.TableStream([21, 30], header_row=['Property', 'Value'])
-    for prop in meta.DOCSUM_ATTRIBS:
-        value = getattr(meta, prop)
-        if value is not None:
-            # TODO: pretty printing for strings, dates, numbers
-            # TODO: better unicode handling
-            # print('- %s: %s' % (prop, value))
-            # if isinstance(value, unicode):
-            #     # encode to UTF8, avoiding errors
-            #     value = value.encode('utf-8', errors='replace')
-            # else:
-            #     value = str(value)
-            t.write_row([prop, value], colors=[None, 'yellow'])
-    t.close()
+        # output_dict = defaultdict.fromkeys(["SUMMARY_ATTRIBS", "DOCSUM_ATTRIBS"], None)
+        output_dict = mydict = {"SUMMARY_ATTRIBS": {}, "DOCSUM_ATTRIBS": {}}
+        for prop in meta.SUMMARY_ATTRIBS:
+            value = getattr(meta, prop)
+            if value is not None:
+                # TODO: pretty printing for strings, dates, numbers
+                # TODO: better unicode handling
+                # print('- %s: %s' % (prop, value))
+                # if isinstance(value, unicode):
+                #     # encode to UTF8, avoiding errors
+                #     value = value.encode('utf-8', errors='replace')
+                # else:
+                #     value = str(value)
+                output_dict['SUMMARY_ATTRIBS'].update(prop = value)
+        for prop in meta.DOCSUM_ATTRIBS:
+            value = getattr(meta, prop)
+            if value is not None:
+                # TODO: pretty printing for strings, dates, numbers
+                # TODO: better unicode handling
+                # print('- %s: %s' % (prop, value))
+                # if isinstance(value, unicode):
+                #     # encode to UTF8, avoiding errors
+                #     value = value.encode('utf-8', errors='replace')
+                # else:
+                #     value = str(value)
+                output_dict['DOCSUM_ATTRIBS'][prop] = value
+
+        print(output_dict)
+
+
+
+
 
 
 # === MAIN ===================================================================
@@ -143,12 +181,17 @@ def main():
                       help='if the file is a zip archive, open all files from it, using the provided password (requires Python 2.6+)')
     parser.add_option("-f", "--zipfname", dest='zip_fname', type='str', default='*',
                       help='if the file is a zip archive, file(s) to be opened within the zip. Wildcards * and ? are supported. (default:*)')
+    parser.add_option("-o", "--output", dest='output', type='str', default="table",
+                      help="output in 'table' or 'json' format")
 
     # TODO: add logfile option
     # parser.add_option('-l', '--loglevel', dest="loglevel", action="store", default=DEFAULT_LOG_LEVEL,
     #                         help="logging level debug/info/warning/error/critical (default=%default)")
 
     (options, args) = parser.parse_args()
+
+    if options.output not in ('json', 'table'):
+        parser.error("Allowed options are 'json' or 'table'")
 
     # Print help if no arguments are passed
     if len(args) == 0:
@@ -171,7 +214,8 @@ def main():
         else:
             # normal filename
             ole = olefile.OleFileIO(filename)
-        process_ole(ole)
+        meta = process_ole(ole)
+        process_output(meta, options.output)
         ole.close()
 
 if __name__ == '__main__':

--- a/oletools/olemeta.py
+++ b/oletools/olemeta.py
@@ -130,6 +130,8 @@ def process_output(meta, output):
                 t.write_row([prop, value], colors=[None, 'yellow'])
         t.close()
     else:
+        # initalize a dictionary with keys for each type of attribute
+        # update props/values like the table would
         output_dict = {"SUMMARY_ATTRIBS": {}, "DOCSUM_ATTRIBS": {}}
         for prop in meta.SUMMARY_ATTRIBS:
             value = getattr(meta, prop)
@@ -196,6 +198,7 @@ def main():
         else:
             # normal filename
             ole = olefile.OleFileIO(filename)
+        # multiple outputs need to flow differently, 
         meta = process_ole(ole)
         process_output(meta, options.output)
         ole.close()


### PR DESCRIPTION
Update olemeta to provide json output with -o flag and to be run imported into other tools.

The olemeta tool works great to provide a table format for interactive use of the tool. I want to be able to import the tool into other scripts to automate some triage of malicious documents. This change would allow the user to provide a -o flag at runtime to generate output in json. Normal use of the tool would not change, but it could now be imported into other tools with something like:

```
from oletools import olemeta
import olefile

with open('file.doc', 'rb') as file:
    output = 'json'
    ole = olefile.OleFileIO(file)
    meta = olemeta.process_ole(ole)
    json_metadata = olemeta.process_output(meta, output)
    print(json_metadata)
```